### PR TITLE
feat: add first-seen vulnerability tracking and dashboard improvements

### DIFF
--- a/backend/alembic/versions/d1e2f3a4b5c6_add_first_seen_at_to_vulnerability.py
+++ b/backend/alembic/versions/d1e2f3a4b5c6_add_first_seen_at_to_vulnerability.py
@@ -1,0 +1,48 @@
+"""add first_seen_at to vulnerability
+
+Revision ID: d1e2f3a4b5c6
+Revises: c3d4e5f6a7b8
+Create Date: 2026-03-04 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd1e2f3a4b5c6'
+down_revision: Union[str, Sequence[str], None] = 'c3d4e5f6a7b8'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Add first_seen_at column and backfill from earliest scan per (image_repository, vuln_id, package_name, installed_version)."""
+    # Step 1: add as nullable
+    op.add_column('vulnerability', sa.Column('first_seen_at', sa.DateTime(), nullable=True))
+
+    # Step 2: backfill — for each vulnerability, set first_seen_at to the earliest
+    # scanned_at across all scans of the same image_repository that contain the same
+    # (vuln_id, package_name, installed_version) tuple.
+    bind = op.get_bind()
+    bind.execute(sa.text("""
+        UPDATE vulnerability
+        SET first_seen_at = (
+            SELECT MIN(s.scanned_at)
+            FROM scan s
+            JOIN vulnerability v2 ON v2.scan_id = s.id
+            WHERE v2.vuln_id = vulnerability.vuln_id
+              AND v2.package_name = vulnerability.package_name
+              AND v2.installed_version = vulnerability.installed_version
+              AND s.image_repository = (
+                  SELECT image_repository FROM scan WHERE id = vulnerability.scan_id
+              )
+        )
+    """))
+
+
+def downgrade() -> None:
+    """Remove first_seen_at column from vulnerability table."""
+    op.drop_column('vulnerability', 'first_seen_at')

--- a/backend/alembic/versions/e2f3a4b5c6d7_add_grype_info_to_app_state.py
+++ b/backend/alembic/versions/e2f3a4b5c6d7_add_grype_info_to_app_state.py
@@ -1,0 +1,28 @@
+"""add grype_version and db_built to app_state
+
+Revision ID: e2f3a4b5c6d7
+Revises: d1e2f3a4b5c6
+Create Date: 2026-03-04 13:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'e2f3a4b5c6d7'
+down_revision: Union[str, Sequence[str], None] = 'd1e2f3a4b5c6'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('appstate', sa.Column('grype_version', sa.Text(), nullable=True))
+    op.add_column('appstate', sa.Column('db_built', sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('appstate', 'db_built')
+    op.drop_column('appstate', 'grype_version')

--- a/backend/api.py
+++ b/backend/api.py
@@ -317,19 +317,31 @@ def get_dashboard_summary(session: Session = Depends(db.get_session)):
         for day in sorted(day_image_scan.keys())
     ]
 
-    # Status bar fields: grype version, vuln DB built date, last db check time
-    latest_scan = session.exec(select(Scan).order_by(Scan.scanned_at.desc()).limit(1)).first()
-    grype_version = latest_scan.grype_version if latest_scan else None
-    db_built = _as_utc(latest_scan.db_built) if latest_scan else None
-
+    # Status bar fields: prefer AppState (updated each hourly DB check) so values
+    # are always current; fall back to latest scan for installs that haven't
+    # yet run a DB check with the updated scheduler.
     app_state = session.get(AppState, 1)
     last_db_checked_at = _as_utc(app_state.last_db_checked_at) if app_state else None
+    grype_version = (app_state.grype_version if app_state else None)
+    db_built = _as_utc(app_state.db_built) if app_state else None
+
+    if not grype_version or not db_built:
+        latest_scan = session.exec(select(Scan).order_by(Scan.scanned_at.desc()).limit(1)).first()
+        grype_version = grype_version or (latest_scan.grype_version if latest_scan else None)
+        db_built = db_built or (_as_utc(latest_scan.db_built) if latest_scan else None)
+
+    cutoff_24h = datetime.now(timezone.utc) - timedelta(hours=24)
+    new_vulns_24h = session.exec(
+        select(func.count(Vulnerability.id))
+        .where(Vulnerability.first_seen_at >= cutoff_24h)
+    ).one()
 
     return {
         "running_containers": len(running),
         "images_scanned": images_scanned,
         "critical_count": critical_count,
         "kev_count": kev_count,
+        "new_vulns_24h": int(new_vulns_24h),
         "trend": trend,
         "docker_connected": docker_connected,
         "grype_version": grype_version,

--- a/backend/grype_scanner.py
+++ b/backend/grype_scanner.py
@@ -3,7 +3,7 @@ import logging
 import subprocess
 from datetime import datetime, timezone
 
-from sqlmodel import Session
+from sqlmodel import Session, func, select
 
 from .database import Database, db
 from .docker_watcher import DockerWatcher
@@ -72,71 +72,103 @@ class GrypeScanner:
         distro = grype_json.get("distro", {})
         descriptor = grype_json.get("descriptor", {})
         db_info = descriptor.get("db", {})
+        # Grype v6+ nests the built date under db.status; fall back to db.built for older versions.
+        db_status = db_info.get("status", db_info)
+
+        image_repository = _parse_image_repository(image_name)
+        scanned_at = datetime.now(timezone.utc)
 
         scan = Scan(
-            scanned_at=datetime.now(timezone.utc),
+            scanned_at=scanned_at,
             image_name=image_name,
-            image_repository=_parse_image_repository(image_name),
+            image_repository=image_repository,
             image_digest=target.get("imageID", ""),
             grype_version=descriptor.get("version", ""),
-            db_built=self._parse_datetime(db_info.get("built")),
+            db_built=self._parse_datetime(db_status.get("built")),
             distro_name=distro.get("name") or None,
             distro_version=distro.get("version") or None,
             container_name=container_name,
         )
 
-        vulnerabilities = []
-        for match in grype_json.get("matches", []):
-            vuln = match.get("vulnerability", {})
-            artifact = match.get("artifact", {})
-            fix = vuln.get("fix", {})
-
-            cvss_list = vuln.get("cvss", [])
-            cvss_base_score = None
-            if cvss_list:
-                cvss_base_score = cvss_list[0].get("metrics", {}).get("baseScore")
-
-            epss_list = vuln.get("epss", [])
-            epss_score = None
-            epss_percentile = None
-            if epss_list:
-                epss_score = epss_list[0].get("epss")
-                epss_percentile = epss_list[0].get("percentile")
-
-            cwes_list = vuln.get("cwes", [])
-            cwes = ",".join(c.get("cwe", "") for c in cwes_list) if cwes_list else None
-
-            urls_list = vuln.get("urls", [])
-            urls = ",".join(urls_list) if urls_list else None
-
-            fix_versions = fix.get("versions", [])
-            fixed_version = fix_versions[0] if fix_versions else None
-
-            vulnerabilities.append(Vulnerability(
-                vuln_id=vuln.get("id", ""),
-                severity=vuln.get("severity", ""),
-                description=vuln.get("description") or None,
-                data_source=vuln.get("dataSource") or None,
-                urls=urls,
-                cvss_base_score=cvss_base_score,
-                epss_score=epss_score,
-                epss_percentile=epss_percentile,
-                is_kev=bool(vuln.get("knownExploited")),
-                risk_score=vuln.get("risk"),
-                cwes=cwes,
-                package_name=artifact.get("name", ""),
-                installed_version=artifact.get("version", ""),
-                fixed_version=fixed_version,
-                fix_state=fix.get("state") or None,
-                package_type=artifact.get("type") or None,
-                package_language=artifact.get("language") or None,
-                purl=artifact.get("purl") or None,
-                locations="\n".join(
-                    loc["path"] for loc in artifact.get("locations", []) if loc.get("path")
-                ) or None,
-            ))
-
         with Session(self.db.engine) as session:
+            # Build lookup: (vuln_id, package_name, installed_version) -> earliest first_seen_at
+            # scoped to this image_repository so "new" is per-repo not per-tag.
+            existing_rows = session.exec(
+                select(
+                    Vulnerability.vuln_id,
+                    Vulnerability.package_name,
+                    Vulnerability.installed_version,
+                    func.min(Vulnerability.first_seen_at),
+                )
+                .join(Scan, Vulnerability.scan_id == Scan.id)
+                .where(Scan.image_repository == image_repository)
+                .group_by(
+                    Vulnerability.vuln_id,
+                    Vulnerability.package_name,
+                    Vulnerability.installed_version,
+                )
+            ).all()
+            first_seen_map: dict[tuple[str, str, str], datetime] = {
+                (r[0], r[1], r[2]): r[3] for r in existing_rows if r[3] is not None
+            }
+
+            vulnerabilities = []
+            for match in grype_json.get("matches", []):
+                vuln = match.get("vulnerability", {})
+                artifact = match.get("artifact", {})
+                fix = vuln.get("fix", {})
+
+                cvss_list = vuln.get("cvss", [])
+                cvss_base_score = None
+                if cvss_list:
+                    cvss_base_score = cvss_list[0].get("metrics", {}).get("baseScore")
+
+                epss_list = vuln.get("epss", [])
+                epss_score = None
+                epss_percentile = None
+                if epss_list:
+                    epss_score = epss_list[0].get("epss")
+                    epss_percentile = epss_list[0].get("percentile")
+
+                cwes_list = vuln.get("cwes", [])
+                cwes = ",".join(c.get("cwe", "") for c in cwes_list) if cwes_list else None
+
+                urls_list = vuln.get("urls", [])
+                urls = ",".join(urls_list) if urls_list else None
+
+                fix_versions = fix.get("versions", [])
+                fixed_version = fix_versions[0] if fix_versions else None
+
+                vuln_id = vuln.get("id", "")
+                package_name = artifact.get("name", "")
+                installed_version = artifact.get("version", "")
+                key = (vuln_id, package_name, installed_version)
+
+                vulnerabilities.append(Vulnerability(
+                    vuln_id=vuln_id,
+                    severity=vuln.get("severity", ""),
+                    description=vuln.get("description") or None,
+                    data_source=vuln.get("dataSource") or None,
+                    urls=urls,
+                    cvss_base_score=cvss_base_score,
+                    epss_score=epss_score,
+                    epss_percentile=epss_percentile,
+                    is_kev=bool(vuln.get("knownExploited")),
+                    risk_score=vuln.get("risk"),
+                    cwes=cwes,
+                    package_name=package_name,
+                    installed_version=installed_version,
+                    fixed_version=fixed_version,
+                    fix_state=fix.get("state") or None,
+                    package_type=artifact.get("type") or None,
+                    package_language=artifact.get("language") or None,
+                    purl=artifact.get("purl") or None,
+                    locations="\n".join(
+                        loc["path"] for loc in artifact.get("locations", []) if loc.get("path")
+                    ) or None,
+                    first_seen_at=first_seen_map.get(key, scanned_at),
+                ))
+
             session.add(scan)
             session.flush()
             for v in vulnerabilities:

--- a/backend/models.py
+++ b/backend/models.py
@@ -43,6 +43,7 @@ class Vulnerability(SQLModel, table=True):
     package_language: Optional[str] = None
     purl: Optional[str] = None
     locations: Optional[str] = None  # newline-separated file paths
+    first_seen_at: Optional[datetime] = None
 
     scan: Optional[Scan] = Relationship(back_populates="vulnerabilities")
 
@@ -51,3 +52,5 @@ class AppState(SQLModel, table=True):
     """Single-row table (id=1) for app-wide persistent state."""
     id: int = Field(default=1, primary_key=True)
     last_db_checked_at: Optional[datetime] = None
+    grype_version: Optional[str] = None
+    db_built: Optional[datetime] = None

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -119,15 +119,51 @@ class ContainerScheduler:
                     result.stderr.strip(),
                 )
 
+        grype_version, db_built = await self._fetch_grype_info()
+
         with Session(self.db.engine) as session:
             state = session.get(AppState, 1)
             if state is None:
-                session.add(AppState(id=1, last_db_checked_at=now))
+                session.add(AppState(id=1, last_db_checked_at=now, grype_version=grype_version, db_built=db_built))
             else:
                 state.last_db_checked_at = now
+                if grype_version:
+                    state.grype_version = grype_version
+                if db_built:
+                    state.db_built = db_built
                 session.add(state)
             session.commit()
-        logger.debug("Persisted last_db_checked_at = %s", now)
+        logger.debug("Persisted last_db_checked_at = %s, grype_version = %s, db_built = %s", now, grype_version, db_built)
+
+    async def _fetch_grype_info(self) -> tuple[str | None, "datetime | None"]:
+        """Run grype version + grype db status to get current grype version and DB built date."""
+        grype_version: str | None = None
+        db_built: "datetime | None" = None
+
+        try:
+            ver_result = await asyncio.to_thread(
+                subprocess.run, ["grype", "version"], capture_output=True, text=True,
+            )
+            for line in ver_result.stdout.splitlines():
+                if line.startswith("Version:"):
+                    grype_version = line.split(":", 1)[1].strip()
+                    break
+        except Exception as e:
+            logger.warning("Could not determine grype version: %s", e)
+
+        try:
+            db_result = await asyncio.to_thread(
+                subprocess.run, ["grype", "db", "status"], capture_output=True, text=True,
+            )
+            for line in db_result.stdout.splitlines():
+                if line.startswith("Built:"):
+                    built_str = line.split(":", 1)[1].strip()
+                    db_built = datetime.fromisoformat(built_str.replace("Z", "+00:00"))
+                    break
+        except Exception as e:
+            logger.warning("Could not determine grype DB built date: %s", e)
+
+        return grype_version, db_built
 
     async def _scan_image_async(self, image_name: str, grype_ref: str, container_name: str | None = None) -> None:
         """Run a Grype scan in a thread so the event loop is not blocked.

--- a/frontend/src/routes/+page.server.ts
+++ b/frontend/src/routes/+page.server.ts
@@ -12,7 +12,7 @@ export const load: PageServerLoad = async ({ fetch }) => {
 	const summary =
 		summaryRes?.ok
 			? await summaryRes.json()
-			: { running_containers: null, images_scanned: null, critical_count: null, kev_count: null, trend: [], docker_connected: false, grype_version: null, db_built: null, last_db_checked_at: null };
+			: { running_containers: null, images_scanned: null, critical_count: null, kev_count: null, new_vulns_24h: 0, trend: [], docker_connected: false, grype_version: null, db_built: null, last_db_checked_at: null };
 
 	const activities = activityRes?.ok ? (await activityRes.json()).activities ?? [] : [];
 

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -113,7 +113,7 @@
 	</div>
 
 	<!-- Stat cards -->
-	<div class="grid max-w-lg gap-4 sm:grid-cols-2">
+	<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
 		<!-- Running containers + images scanned -->
 		<Card.Root>
 			<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
@@ -134,10 +134,10 @@
 			</Card.Content>
 		</Card.Root>
 
-		<!-- Critical + KEV -->
+		<!-- Critical vulnerabilities -->
 		<Card.Root>
 			<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
-				<Card.Title class="text-sm font-medium">Active Threats</Card.Title>
+				<Card.Title class="text-sm font-medium">Critical Vulnerabilities</Card.Title>
 				<TriangleAlert class="text-muted-foreground h-4 w-4" />
 			</Card.Header>
 			<Card.Content>
@@ -145,19 +145,46 @@
 					<div class="text-2xl font-bold">—</div>
 					<p class="text-muted-foreground text-xs">No data yet</p>
 				{:else}
-					<div class="flex items-end gap-4">
-						<div>
-							<div class="text-2xl font-bold">{data.summary.critical_count}</div>
-							<p class="text-muted-foreground text-xs">critical</p>
-						</div>
-						<div class="border-border border-l pl-4">
-							<div class="flex items-center gap-1 text-2xl font-bold {data.summary.kev_count > 0 ? 'text-red-600 dark:text-red-400' : ''}">
-								{#if data.summary.kev_count > 0}<Zap class="h-4 w-4" />{/if}
-								{data.summary.kev_count}
-							</div>
-							<p class="text-muted-foreground text-xs">actively exploited</p>
-						</div>
+					<div class="text-2xl font-bold">{data.summary.critical_count}</div>
+					<p class="text-muted-foreground text-xs">across running containers</p>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		<!-- Actively exploited (KEV) -->
+		<Card.Root>
+			<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
+				<Card.Title class="text-sm font-medium">Actively Exploited</Card.Title>
+				<Zap class="text-muted-foreground h-4 w-4" />
+			</Card.Header>
+			<Card.Content>
+				{#if data.summary.kev_count === null}
+					<div class="text-2xl font-bold">—</div>
+					<p class="text-muted-foreground text-xs">No data yet</p>
+				{:else}
+					<div class="text-2xl font-bold {data.summary.kev_count > 0 ? 'text-red-600 dark:text-red-400' : ''}">
+						{data.summary.kev_count}
 					</div>
+					<p class="text-muted-foreground text-xs">known exploited vulnerabilities (KEV)</p>
+				{/if}
+			</Card.Content>
+		</Card.Root>
+
+		<!-- New vulnerabilities (24h) -->
+		<Card.Root>
+			<Card.Header class="flex flex-row items-center justify-between space-y-0 pb-2">
+				<Card.Title class="text-sm font-medium">New (Last 24h)</Card.Title>
+				<Shield class="text-muted-foreground h-4 w-4" />
+			</Card.Header>
+			<Card.Content>
+				{#if data.summary.new_vulns_24h === null}
+					<div class="text-2xl font-bold">—</div>
+					<p class="text-muted-foreground text-xs">No data yet</p>
+				{:else}
+					<div class="text-2xl font-bold {(data.summary.new_vulns_24h ?? 0) > 0 ? 'text-amber-600 dark:text-amber-400' : ''}">
+						{data.summary.new_vulns_24h ?? 0}
+					</div>
+					<p class="text-muted-foreground text-xs">newly discovered vulnerabilities</p>
 				{/if}
 			</Card.Content>
 		</Card.Root>
@@ -189,10 +216,14 @@
 								color: chartConfig.critical.color
 							}
 						]}
-						axis="x"
+						axis={true}
 						props={{
 							xAxis: {
 								format: (d: string) => d
+							},
+							yAxis: {
+								format: (d: number) => Number.isInteger(d) ? String(d) : '',
+								ticks: 4
 							}
 						}}
 					>

--- a/frontend/src/routes/containers/+page.svelte
+++ b/frontend/src/routes/containers/+page.svelte
@@ -30,6 +30,7 @@
 		package_type: string | null;
 		locations: string | null;
 		epss_percentile: number | null;
+		first_seen_at: string | null;
 	}
 
 	const SEVERITY_ORDER = ['Critical', 'High', 'Medium', 'Low', 'Negligible', 'Unknown'];
@@ -88,13 +89,64 @@
 	// ── Expandable row state ───────────────────────────────────────────────────
 	let expandedContainers = new SvelteSet<string>();
 	let containerVulns = new SvelteMap<string, Vulnerability[]>();
+	let containerScanTimes = new SvelteMap<string, string>(); // imageName -> scanned_at ISO
 	let loadingContainers = new SvelteSet<string>();
 	let activeFilters = new SvelteMap<string, SvelteSet<string>>();
+
+	// ── Progressive rendering state ────────────────────────────────────────────
+	const BATCH_SIZE = 50;
+	let pendingVulns = new SvelteMap<string, Vulnerability[]>(); // remaining items not yet rendered
+	let pendingCallbacks = new Map<string, number>(); // idle/timeout handle per container (not reactive)
+
+	function scheduleNextBatch(imageName: string) {
+		const remaining = pendingVulns.get(imageName);
+		if (!remaining || remaining.length === 0) {
+			pendingVulns.delete(imageName);
+			return;
+		}
+		const batch = remaining.slice(0, BATCH_SIZE);
+		const rest = remaining.slice(BATCH_SIZE);
+		const id =
+			typeof requestIdleCallback !== 'undefined'
+				? requestIdleCallback(
+						() => {
+							containerVulns.set(imageName, [...(containerVulns.get(imageName) ?? []), ...batch]);
+							pendingCallbacks.delete(imageName);
+							if (rest.length > 0) {
+								pendingVulns.set(imageName, rest);
+								scheduleNextBatch(imageName);
+							} else {
+								pendingVulns.delete(imageName);
+							}
+						},
+						{ timeout: 2000 }
+					)
+				: (setTimeout(() => {
+						containerVulns.set(imageName, [...(containerVulns.get(imageName) ?? []), ...batch]);
+						pendingCallbacks.delete(imageName);
+						if (rest.length > 0) {
+							pendingVulns.set(imageName, rest);
+							scheduleNextBatch(imageName);
+						} else {
+							pendingVulns.delete(imageName);
+						}
+					}, 0) as unknown as number);
+		pendingCallbacks.set(imageName, id);
+	}
+
+	function cancelPendingBatch(imageName: string) {
+		const id = pendingCallbacks.get(imageName);
+		if (id !== undefined) {
+			if (typeof cancelIdleCallback !== 'undefined') cancelIdleCallback(id);
+			else clearTimeout(id);
+			pendingCallbacks.delete(imageName);
+		}
+	}
 
 	// ── Sub-table sort (per-container, three-way: none → asc → desc → none) ──
 	type VulnSortCol =
 		| 'vuln_id' | 'severity' | 'package_name'
-		| 'cvss_base_score' | 'epss_score' | 'is_kev';
+		| 'cvss_base_score' | 'epss_score' | 'is_kev' | 'first_seen_at';
 	interface VulnSort { col: VulnSortCol | null; dir: 'asc' | 'desc' }
 	let vulnSortStates = new SvelteMap<string, VulnSort>();
 
@@ -145,12 +197,24 @@
 				}
 				case 'is_kev':
 					return m * ((b.is_kev ? 1 : 0) - (a.is_kev ? 1 : 0));
+				case 'first_seen_at': {
+					if (!a.first_seen_at && !b.first_seen_at) return 0;
+					if (!a.first_seen_at) return 1;
+					if (!b.first_seen_at) return -1;
+					return m * (a.first_seen_at < b.first_seen_at ? -1 : a.first_seen_at > b.first_seen_at ? 1 : 0);
+				}
 			}
 		});
 	}
 
+	function toUtcDate(iso: string): Date {
+		// SQLite stores UTC datetimes without a timezone suffix; append Z so the
+		// browser treats them as UTC rather than local time.
+		return new Date(iso.endsWith('Z') || iso.includes('+') ? iso : iso + 'Z');
+	}
+
 	function timeAgo(iso: string): string {
-		return formatDistanceToNow(new Date(iso), { addSuffix: true });
+		return formatDistanceToNow(toUtcDate(iso), { addSuffix: true });
 	}
 
 	function activeSeverities(vulnsBySeverity: Record<string, number>) {
@@ -166,13 +230,19 @@
 			const raw: Vulnerability[] = Array.isArray(payload)
 				? payload
 				: (payload.vulnerabilities ?? []);
+			if (payload.scanned_at) containerScanTimes.set(imageName, payload.scanned_at);
 			const sorted = raw.slice().sort((a, b) => {
 				const si = SEVERITY_ORDER.indexOf(a.severity);
 				const sj = SEVERITY_ORDER.indexOf(b.severity);
 				if (si !== sj) return si - sj;
 				return (b.cvss_base_score ?? 0) - (a.cvss_base_score ?? 0);
 			});
-			containerVulns.set(imageName, sorted);
+			// Render first batch immediately; schedule the rest via idle callbacks.
+			containerVulns.set(imageName, sorted.slice(0, BATCH_SIZE));
+			if (sorted.length > BATCH_SIZE) {
+				pendingVulns.set(imageName, sorted.slice(BATCH_SIZE));
+				scheduleNextBatch(imageName);
+			}
 		} catch (err) {
 			console.error('Failed to fetch vulns for', imageName, err);
 			containerVulns.set(imageName, []);
@@ -187,6 +257,7 @@
 		if (!hasScan) return;
 		if (expandedContainers.has(imageName)) {
 			expandedContainers.delete(imageName);
+			cancelPendingBatch(imageName);
 		} else {
 			const isFirstOpen = !containerVulns.has(imageName);
 			expandedContainers.add(imageName);
@@ -199,6 +270,9 @@
 						activeFilters.set(imageName, new SvelteSet([topSeverity]));
 					}
 				}
+			} else if (pendingVulns.has(imageName) && !pendingCallbacks.has(imageName)) {
+				// Re-expanded mid-load after collapse — resume batch rendering
+				scheduleNextBatch(imageName);
 			}
 		}
 	}
@@ -255,6 +329,16 @@
 		if (score >= 0.1) return 'font-semibold text-orange-600 dark:text-orange-400';
 		if (score >= 0.01) return 'text-amber-600 dark:text-amber-400';
 		return 'text-muted-foreground';
+	}
+
+	function isNew(vuln: Vulnerability, scannedAt: string | undefined): boolean {
+		if (!vuln.first_seen_at || !scannedAt) return false;
+		// Compare as UTC timestamps to avoid timezone-skewed mismatches
+		return toUtcDate(vuln.first_seen_at).getTime() === toUtcDate(scannedAt).getTime();
+	}
+
+	function formatDate(iso: string): string {
+		return toUtcDate(iso).toLocaleString();
 	}
 </script>
 
@@ -398,15 +482,16 @@
 													<div class="overflow-x-auto">
 														<Table.Root class="w-full table-fixed text-xs">
 															<colgroup>
-																<col style="width:13%" />
+																<col style="width:12%" />
 																<col style="width:7%" />
-																<col style="width:14%" />
-																<col style="width:9%" />
-																<col style="width:9%" />
-																<col style="width:6%" />
-																<col style="width:7%" />
+																<col style="width:12%" />
+																<col style="width:8%" />
+																<col style="width:8%" />
 																<col style="width:5%" />
-																<col style="width:30%" />
+																<col style="width:6%" />
+																<col style="width:4%" />
+																<col style="width:10%" />
+																<col style="width:28%" />
 															</colgroup>
 															<Table.Header>
 																<Table.Row class="bg-muted/30">
@@ -491,6 +576,14 @@
 																			</Tooltip.Content>
 																		</Tooltip.Root>
 																	</Table.Head>
+																	<Table.Head class="text-center">
+																		<SortButton
+																			label="First Seen"
+																			size="sm"
+																			sortDirection={vulnSortDir(container.image_name, 'first_seen_at')}
+																			onclick={(e) => toggleVulnSort(container.image_name, 'first_seen_at', e)}
+																		/>
+																	</Table.Head>
 																	<Table.Head class="pr-6">Description</Table.Head>
 																</Table.Row>
 															</Table.Header>
@@ -498,17 +591,24 @@
 																{#each vulns as vuln (vuln.vuln_id + vuln.package_name + vuln.installed_version)}
 																	<Table.Row class="hover:bg-muted/30">
 																		<Table.Cell class="pl-2 font-mono">
-																			<a
-																				href={vuln.data_source ??
-																					`https://nvd.nist.gov/vuln/detail/${vuln.vuln_id}`}
-																				target="_blank"
-																				rel="noopener noreferrer"
-																				onclick={(e) => e.stopPropagation()}
-																				class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
-																			>
-																				{vuln.vuln_id}
-																				<ExternalLink class="h-3 w-3 shrink-0" />
-																			</a>
+																			<div class="flex flex-wrap items-center gap-1">
+																				<a
+																					href={vuln.data_source ??
+																						`https://nvd.nist.gov/vuln/detail/${vuln.vuln_id}`}
+																					target="_blank"
+																					rel="noopener noreferrer"
+																					onclick={(e) => e.stopPropagation()}
+																					class="inline-flex items-center gap-1 text-blue-600 hover:underline dark:text-blue-400"
+																				>
+																					{vuln.vuln_id}
+																					<ExternalLink class="h-3 w-3 shrink-0" />
+																				</a>
+																				{#if isNew(vuln, containerScanTimes.get(container.image_name))}
+																					<span class="inline-flex items-center rounded-full border border-emerald-200 bg-emerald-100 px-1.5 py-0.5 font-sans text-[10px] font-semibold text-emerald-700 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300">
+																						NEW
+																					</span>
+																				{/if}
+																			</div>
 																		</Table.Cell>
 																		<Table.Cell class="text-center">
 																			<span
@@ -612,6 +712,18 @@
 																				</Tooltip.Root>
 																			{/if}
 																		</Table.Cell>
+																		<Table.Cell class="text-center">
+																			{#if vuln.first_seen_at}
+																				<Tooltip.Root>
+																					<Tooltip.Trigger class="cursor-default text-xs text-muted-foreground">
+																						{timeAgo(vuln.first_seen_at)}
+																					</Tooltip.Trigger>
+																					<Tooltip.Content>{formatDate(vuln.first_seen_at)}</Tooltip.Content>
+																				</Tooltip.Root>
+																			{:else}
+																				<span class="text-muted-foreground">—</span>
+																			{/if}
+																		</Table.Cell>
 																		<Table.Cell class="text-muted-foreground pr-6">
 																			<span title={vuln.description ?? undefined}>
 																				{truncate(vuln.description)}
@@ -624,9 +736,15 @@
 													</div>
 												{/if}
 											{/if}
-										</div>
-									</Table.Cell>
-								</Table.Row>
+										{#if pendingVulns.has(container.image_name)}
+											<div class="flex items-center gap-2 border-t px-6 py-2 text-xs text-muted-foreground">
+												<Loader2 class="h-3 w-3 animate-spin" />
+												<span>Loading {pendingVulns.get(container.image_name)?.length ?? 0} more vulnerabilities…</span>
+											</div>
+										{/if}
+									</div>
+								</Table.Cell>
+							</Table.Row>
 							{/if}
 						{/each}
 					</Table.Body>


### PR DESCRIPTION
- Add `first_seen_at` column to Vulnerability table, backfilled via Alembic migration using earliest scan per (vuln_id, package, version, image_repository) so "new" is scoped per image repository
- Scanner populates first_seen_at on each new scan, preserving the original date when a CVE has been seen before in the same repo
- Containers page: "NEW" badge on CVEs first seen in the current scan, sortable "First Seen" column with relative time + tooltip; UTC normalization fix so timestamps display correctly in local time; progressive batch rendering carried in from master working tree
- Dashboard: four individual stat cards (Environment, Critical, Actively Exploited, New 24h) in a 4-column grid; y-axis added to 30-day trend chart
- Fix Grype v6 db_built JSON path (descriptor.db.status.built); store grype_version + db_built in AppState updated each hourly DB check so status bar shows values immediately on startup without waiting for a scan