### PR TITLE
fix: reduce vuln list hang via severity filter and payload truncation

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,4 +1,6 @@
 import colorlog
+import logging
+import time
 from collections import defaultdict
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -11,6 +13,23 @@ from .database import db
 from .docker_watcher import DockerWatcher
 from .models import AppState, Scan, Vulnerability
 from .scheduler import ContainerScheduler
+
+logger = logging.getLogger(__name__)
+
+_DESC_LIMIT = 250
+_LOC_LIMIT = 5
+
+
+def _serialise_vuln(v: Vulnerability) -> dict:
+    """Convert a Vulnerability ORM object to a dict, truncating large text fields."""
+    d = v.model_dump()
+    if d.get("description") and len(d["description"]) > _DESC_LIMIT:
+        d["description"] = d["description"][:_DESC_LIMIT] + "…"
+    if d.get("locations"):
+        paths = d["locations"].split("\n")
+        if len(paths) > _LOC_LIMIT:
+            d["locations"] = "\n".join(paths[:_LOC_LIMIT])
+    return d
 
 
 @asynccontextmanager
@@ -84,14 +103,24 @@ def _parse_image_query(image: str) -> tuple[str, str]:
 @app.get("/images/vulnerabilities")
 def get_vulnerabilities(
     image_ref: str = Query(..., description="Image reference: name+tag (nginx:latest) or digest (sha256:...)"),
+    severity: str | None = Query(None, description="Filter by severity (e.g. Critical, High)"),
     session: Session = Depends(db.get_session),
 ):
-    """All vulnerabilities for the most recent scan of an image."""
+    """Vulnerabilities for the most recent scan of an image, optionally filtered by severity."""
+    t0 = time.perf_counter()
     scan = _latest_scan_for_ref(image_ref, session)
-    vulns = session.exec(
-        select(Vulnerability).where(Vulnerability.scan_id == scan.id)
-    ).all()
-    return {"scan_id": scan.id, "scanned_at": _as_utc(scan.scanned_at), "count": len(vulns), "vulnerabilities": vulns}
+    q = select(Vulnerability).where(Vulnerability.scan_id == scan.id)
+    if severity:
+        q = q.where(Vulnerability.severity == severity)
+    vulns = session.exec(q).all()
+    serialised = [_serialise_vuln(v) for v in vulns]
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    payload_est = sum(len(d.get("description") or "") + len(d.get("locations") or "") for d in serialised)
+    logger.info(
+        "GET /images/vulnerabilities image_ref=%s severity=%s count=%d payload_est=%dB db_ms=%.1f",
+        image_ref, severity, len(serialised), payload_est, elapsed_ms,
+    )
+    return {"scan_id": scan.id, "scanned_at": _as_utc(scan.scanned_at), "count": len(serialised), "vulnerabilities": serialised}
 
 
 @app.get("/images/vulnerabilities/critical")
@@ -106,7 +135,8 @@ def get_critical_vulnerabilities(
         .where(Vulnerability.scan_id == scan.id)
         .where(Vulnerability.severity == "Critical")
     ).all()
-    return {"scan_id": scan.id, "scanned_at": _as_utc(scan.scanned_at), "count": len(vulns), "vulnerabilities": vulns}
+    serialised = [_serialise_vuln(v) for v in vulns]
+    return {"scan_id": scan.id, "scanned_at": _as_utc(scan.scanned_at), "count": len(serialised), "vulnerabilities": serialised}
 
 
 @app.get("/vulnerabilities/critical/running")

--- a/frontend/src/routes/api/vulnerabilities/+server.ts
+++ b/frontend/src/routes/api/vulnerabilities/+server.ts
@@ -6,9 +6,10 @@ const API_URL = env.API_URL ?? 'http://localhost:8765';
 export const GET: RequestHandler = async ({ url, fetch }) => {
 	const imageRef = url.searchParams.get('image_ref');
 	if (!imageRef) return new Response('Missing image_ref', { status: 400 });
-	const res = await fetch(
-		`${API_URL}/images/vulnerabilities?image_ref=${encodeURIComponent(imageRef)}`
-	);
+	const severity = url.searchParams.get('severity');
+	let backendUrl = `${API_URL}/images/vulnerabilities?image_ref=${encodeURIComponent(imageRef)}`;
+	if (severity) backendUrl += `&severity=${encodeURIComponent(severity)}`;
+	const res = await fetch(backendUrl);
 	return new Response(res.body, {
 		status: res.status,
 		headers: { 'content-type': 'application/json' }

--- a/frontend/src/routes/containers/+page.svelte
+++ b/frontend/src/routes/containers/+page.svelte
@@ -92,6 +92,9 @@
 	let containerScanTimes = new SvelteMap<string, string>(); // imageName -> scanned_at ISO
 	let loadingContainers = new SvelteSet<string>();
 	let activeFilters = new SvelteMap<string, SvelteSet<string>>();
+	// Maps imageName → the single severity that was fetched (e.g. 'Critical').
+	// Not reactive — only read inside event handlers.
+	const partiallyLoadedSeverity = new Map<string, string>();
 
 	// ── Progressive rendering state ────────────────────────────────────────────
 	const BATCH_SIZE = 50;
@@ -221,12 +224,23 @@
 		return SEVERITY_ORDER.filter((s) => (vulnsBySeverity[s] ?? 0) > 0);
 	}
 
-	async function fetchVulns(imageName: string) {
+	async function fetchVulns(imageName: string, severity?: string) {
 		loadingContainers.add(imageName);
 		try {
-			const res = await fetch(`/api/vulnerabilities?image_ref=${encodeURIComponent(imageName)}`);
+			const t0 = performance.now();
+			let qs = `/api/vulnerabilities?image_ref=${encodeURIComponent(imageName)}`;
+			if (severity) qs += `&severity=${encodeURIComponent(severity)}`;
+			const res = await fetch(qs);
 			if (!res.ok) throw new Error(`HTTP ${res.status}`);
-			const payload = await res.json();
+			const text = await res.text();
+			const fetchMs = (performance.now() - t0).toFixed(0);
+			const t1 = performance.now();
+			const payload = JSON.parse(text);
+			const parseMs = (performance.now() - t1).toFixed(0);
+			console.log(
+				`[DSW] vuln fetch ${imageName}${severity ? ` (${severity})` : ''}: ` +
+				`${text.length} bytes, fetch=${fetchMs}ms, parse=${parseMs}ms`
+			);
 			const raw: Vulnerability[] = Array.isArray(payload)
 				? payload
 				: (payload.vulnerabilities ?? []);
@@ -242,6 +256,11 @@
 			if (sorted.length > BATCH_SIZE) {
 				pendingVulns.set(imageName, sorted.slice(BATCH_SIZE));
 				scheduleNextBatch(imageName);
+			}
+			if (severity) {
+				partiallyLoadedSeverity.set(imageName, severity);
+			} else {
+				partiallyLoadedSeverity.delete(imageName);
 			}
 		} catch (err) {
 			console.error('Failed to fetch vulns for', imageName, err);
@@ -262,13 +281,16 @@
 			const isFirstOpen = !containerVulns.has(imageName);
 			expandedContainers.add(imageName);
 			if (isFirstOpen) {
-				fetchVulns(imageName);
-				// Auto-filter to highest severity on first open, but only if there are enough vulns
-				if (total >= AUTO_FILTER_THRESHOLD) {
-					const topSeverity = SEVERITY_ORDER.find((s) => (vulnsBySeverity[s] ?? 0) > 0);
-					if (topSeverity) {
-						activeFilters.set(imageName, new SvelteSet([topSeverity]));
-					}
+				// Auto-filter to highest severity on first open when there are many vulns,
+				// and fetch only that severity initially (avoids large payload hang).
+				const topSeverity = total >= AUTO_FILTER_THRESHOLD
+					? SEVERITY_ORDER.find((s) => (vulnsBySeverity[s] ?? 0) > 0)
+					: undefined;
+				if (topSeverity) {
+					activeFilters.set(imageName, new SvelteSet([topSeverity]));
+					fetchVulns(imageName, topSeverity);
+				} else {
+					fetchVulns(imageName);
 				}
 			} else if (pendingVulns.has(imageName) && !pendingCallbacks.has(imageName)) {
 				// Re-expanded mid-load after collapse — resume batch rendering
@@ -283,6 +305,13 @@
 		const filters = activeFilters.get(imageName)!;
 		if (filters.has(severity)) filters.delete(severity);
 		else filters.add(severity);
+		// If we only fetched one severity, check whether the new filter state
+		// requires data we don't have, and if so re-fetch everything.
+		const fetchedSev = partiallyLoadedSeverity.get(imageName);
+		if (fetchedSev) {
+			const needsFull = filters.size === 0 || [...filters].some((s) => s !== fetchedSev);
+			if (needsFull) fetchVulns(imageName);
+		}
 	}
 
 	function isFilterActive(imageName: string, severity: string): boolean {


### PR DESCRIPTION
- Backend: add optional ?severity= filter to GET /images/vulnerabilities so initial expand only fetches the auto-filtered severity (e.g. Critical) instead of all 300+ rows; also truncates description to 250 chars and locations to 5 paths to reduce per-row payload size
- Backend: add timing + payload-size logging to GET /images/vulnerabilities for diagnosing future hang conditions
- Frontend proxy: pass ?severity= param through to backend
- Frontend: use res.text() + JSON.parse() with console timing logs so we can see fetch time, payload bytes, and parse time per expand
- Frontend: fetchVulns() now accepts optional severity and tracks partial loads; toggleExpanded fetches only the top severity on first open; toggleFilter triggers full re-fetch when user needs unloaded severities