### PR TITLE
chore: bump grype v0.110.0 → v0.111.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install grype (for e2e tests)
         run: |
           curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
-            | sh -s -- -b /usr/local/bin v0.110.0
+            | sh -s -- -b /usr/local/bin v0.111.0
 
       - name: Run pytest (including e2e)
         run: uv run pytest -m ""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install grype
 RUN curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh \
-    | sh -s -- -b /usr/local/bin v0.110.0
+    | sh -s -- -b /usr/local/bin v0.111.0
 
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv


### PR DESCRIPTION
## Grype version update

Bumps the pinned Grype scanner from `v0.110.0` to `v0.111.0`.

**Files updated:**
- `docker/Dockerfile` — distributed container image
- `.github/workflows/ci.yml` — e2e test job

**Release notes:** https://github.com/anchore/grype/releases/tag/v0.111.0

**After merging:** rebuild locally and run `grype dockguard:test` to
confirm whether any CVEs in `vex/dockguard.vex.json` were resolved.
If Go stdlib or GHSA entries are patched, remove those VEX statements
and bump the VEX document version.

_Automated by the [Check for Grype Updates](/.github/workflows/update-grype.yml) workflow._
